### PR TITLE
Bump Azure/setup-azd from 1.0.0 to 2.0.0 in the github-actions group

### DIFF
--- a/.github/workflows/azure-dev.yaml
+++ b/.github/workflows/azure-dev.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install azd
-        uses: Azure/setup-azd@v1.0.0
+        uses: Azure/setup-azd@v2.0.0
 
       - name: Install Nodejs
         uses: actions/setup-node@v4


### PR DESCRIPTION
Bumps the github-actions group with 1 update: [Azure/setup-azd](https://github.com/azure/setup-azd).


Updates `Azure/setup-azd` from 1.0.0 to 2.0.0
- [Release notes](https://github.com/azure/setup-azd/releases)
- [Changelog](https://github.com/Azure/setup-azd/blob/main/CHANGELOG.md)
- [Commits](https://github.com/Azure/setup-azd/compare/v1.0.0...v2.0.0)